### PR TITLE
Make it more flexible to use latest version. Make nexus user own the process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@ This repository holds files and scripts to build a Sonatype Nexus .rpm
 package.
 
 # Ingredients
-- Nexus OSS 2.0.6: from http://nexus.sonatype.com
+- Nexus OSS Latest: from http://nexus.sonatype.com
 
 # Licenses
 - Nexus OSS: AGPL, Sonatype
-- Scripts and Spec: AGPL, Jens Braeuer <braeuer.jens@googlemail.com>
+- Scripts and Spec: AGPL, Jens Braeuer <braeuer.jens@googlemail.com>, Ilja Bobkevic <ilja.bobkevic@gmail.com>
 
 # How to build
 - fetch Nexus OSS tar.gz: ./fetch-nexus-oos
@@ -18,17 +18,14 @@ Nexus configuration has been customized, so Nexus behaves more like a
 "real" daemon.
 
 - Logfiles: /var/log/nexus
-- Pidfile: /var/run/
+- Pidfile: /var/run
 - Conf: /etc/nexus
 - Init file: /etc/init.d/nexus
 
 # Current state
 
-This has been tested on Scientific Linux 6.1. It should work on CentOS
-and RHEL too.  Currently Nexus is configured to run as root
-user. While this not perfect, it is better than the manual
-unzip/install steps .
+This has been tested on Scientific Linux 6.1 and CentOS 6.4.
+It should work on  RHEL too.
 
 Have fun!
-Jens
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This repository holds files and scripts to build a Sonatype Nexus .rpm
 package.
 
 # Ingredients
-- Nexus OSS 1.9.2.3: from http://nexus.sonatype.com
+- Nexus OSS 2.0.6: from http://nexus.sonatype.com
 
 # Licenses
 - Nexus OSS: AGPL, Sonatype

--- a/SOURCES/nexus_initd.patch
+++ b/SOURCES/nexus_initd.patch
@@ -1,0 +1,35 @@
+--- nexus-2.5.1-01/bin/nexus.orig	2013-06-28 19:26:12.000000000 +0000
++++ nexus-2.5.1-01/bin/nexus	2013-07-08 13:48:29.951546295 +0000
+@@ -1,4 +1,21 @@
+ #! /bin/sh
++# 
++# nexu Startup script for Nexus OSS
++#
++# chkconfig: 2345 98 02
++# description: Nexus OSS daemon
++
++### BEGIN INIT INFO
++# Provides: nexus
++# Required-Start: $local_fs $network $remote_fs
++# Required-Stop: $local_fs $network $remote_fs
++# Should-Start: $named $time
++# Should-Stop: $named $time
++# Default-Start: 2 3 4 5
++# Default-Stop: 0 1 6
++# Short-Description: Startup script for the Nexus OSS
++# Description: Nexus OSS daemon
++### END INIT INFO
+ 
+ #
+ # Copyright (c) 1999, 2006 Tanuki Software Inc.
+@@ -289,7 +306,9 @@
+     
+             # Still want to change users, recurse.  This means that the user will only be
+             #  prompted for a password once. Variables shifted by 1
+-            su - $RUN_AS_USER -c "\"$REALPATH\" $2"
++            touch $PIDFILE
++            chown $RUN_AS_USER:$RUN_AS_GROUP $PIDFILE
++            sudo -u $RUN_AS_USER $REALPATH $2
+     
+             # Now that we are the original user again, we may need to clean up the lock file.
+             if [ "X$LOCKPROP" != "X" ]

--- a/SPECS/nexus-oss.spec
+++ b/SPECS/nexus-oss.spec
@@ -38,7 +38,7 @@ sed -i -e 's#nexus-work=.*#nexus-work=/var/lib/nexus/#g' $RPM_BUILD_ROOT/usr/sha
 mkdir -p $RPM_BUILD_ROOT/var/lib/nexus
 
 # patch tcp port
-sed -i -e 's#application-port=.*#application-port=80#g' $RPM_BUILD_ROOT/usr/share/%{name}/conf/plexus.properties
+#sed -i -e 's#application-port=.*#application-port=80#g' $RPM_BUILD_ROOT/usr/share/%{name}/conf/plexus.properties
 
 # patch pid dir
 sed -i -e 's#PIDDIR=.*#PIDDIR=/var/run/#' $RPM_BUILD_ROOT/usr/share/%{name}/bin/jsw/linux-$arch/nexus

--- a/SPECS/nexus-oss.spec
+++ b/SPECS/nexus-oss.spec
@@ -26,7 +26,7 @@ mkdir -p $RPM_BUILD_ROOT/usr/share/%{name}
 mv * $RPM_BUILD_ROOT/usr/share/%{name}
 
 arch=$(echo "%{_arch}" | sed -e 's/_/-/')
-arch="x86_64"
+arch="x86-64"
 mkdir -p $RPM_BUILD_ROOT/etc/rc.d/init.d/
 cd $RPM_BUILD_ROOT/etc/rc.d/init.d/
 ln -sf /usr/share/%{name}/bin/jsw/linux-$arch/nexus $RPM_BUILD_ROOT/etc/rc.d/init.d/

--- a/SPECS/nexus-oss.spec
+++ b/SPECS/nexus-oss.spec
@@ -34,7 +34,7 @@ mkdir -p $RPM_BUILD_ROOT/etc/
 ln -sf /usr/share/%{name}/conf $RPM_BUILD_ROOT/etc/nexus
 
 # patch work dir
-sed -i -e 's#nexus-work=.*#nexus-work=/var/lib/nexus/#g' $RPM_BUILD_ROOT/usr/share/%{name}/conf/plexus.properties
+sed -i -e 's#nexus-work=.*#nexus-work=/var/lib/nexus/#g' $RPM_BUILD_ROOT/usr/share/%{name}/conf/nexus.properties
 mkdir -p $RPM_BUILD_ROOT/var/lib/nexus
 
 # patch tcp port

--- a/SPECS/nexus-oss.spec
+++ b/SPECS/nexus-oss.spec
@@ -16,7 +16,7 @@ AutoReqProv: no
 A package repository
 
 %prep
-%setup -q -n %{name}-webapp-%{version}
+%setup -q -n %{name}-%{version}
 
 %build
 

--- a/SPECS/nexus-oss.spec
+++ b/SPECS/nexus-oss.spec
@@ -7,7 +7,6 @@ Group: unknown
 URL: http://nexus.sonatype.org/
 Source0: %{name}-%{version}-bundle.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
-Requires: jdk
 AutoReqProv: no
 
 %define __os_install_post %{nil}

--- a/SPECS/nexus-oss.spec
+++ b/SPECS/nexus-oss.spec
@@ -7,7 +7,6 @@ Group: unknown
 URL: http://nexus.sonatype.org/
 Source0: %{name}-%{version}-bundle.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
-BuildArch:	x86_64
 Requires: jdk
 AutoReqProv: no
 
@@ -27,6 +26,7 @@ mkdir -p $RPM_BUILD_ROOT/usr/share/%{name}
 mv * $RPM_BUILD_ROOT/usr/share/%{name}
 
 arch=$(echo "%{_arch}" | sed -e 's/_/-/')
+arch="x86_64"
 mkdir -p $RPM_BUILD_ROOT/etc/rc.d/init.d/
 cd $RPM_BUILD_ROOT/etc/rc.d/init.d/
 ln -sf /usr/share/%{name}/bin/jsw/linux-$arch/nexus $RPM_BUILD_ROOT/etc/rc.d/init.d/
@@ -42,7 +42,7 @@ mkdir -p $RPM_BUILD_ROOT/var/lib/nexus
 #sed -i -e 's#application-port=.*#application-port=80#g' $RPM_BUILD_ROOT/usr/share/%{name}/conf/plexus.properties
 
 # patch pid dir
-sed -i -e 's#PIDDIR=.*#PIDDIR=/var/run/#' $RPM_BUILD_ROOT/usr/share/%{name}/bin/jsw/linux-%{buildarch}/nexus
+sed -i -e 's#PIDDIR=.*#PIDDIR=/var/run/#' $RPM_BUILD_ROOT/usr/share/%{name}/bin/jsw/linux-$arch/nexus
 
 # patch logfile
 mkdir -p $RPM_BUILD_ROOT/var/log/nexus

--- a/SPECS/nexus-oss.spec
+++ b/SPECS/nexus-oss.spec
@@ -7,6 +7,7 @@ Group: unknown
 URL: http://nexus.sonatype.org/
 Source0: %{name}-%{version}-bundle.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+BuildArch:	x86_64
 Requires: jdk
 AutoReqProv: no
 
@@ -41,7 +42,7 @@ mkdir -p $RPM_BUILD_ROOT/var/lib/nexus
 #sed -i -e 's#application-port=.*#application-port=80#g' $RPM_BUILD_ROOT/usr/share/%{name}/conf/plexus.properties
 
 # patch pid dir
-sed -i -e 's#PIDDIR=.*#PIDDIR=/var/run/#' $RPM_BUILD_ROOT/usr/share/%{name}/bin/jsw/linux-$arch/nexus
+sed -i -e 's#PIDDIR=.*#PIDDIR=/var/run/#' $RPM_BUILD_ROOT/usr/share/%{name}/bin/jsw/linux-%{buildarch}/nexus
 
 # patch logfile
 mkdir -p $RPM_BUILD_ROOT/var/log/nexus

--- a/SPECS/nexus-oss.spec
+++ b/SPECS/nexus-oss.spec
@@ -1,11 +1,11 @@
 Summary: Nexus manages software “artifacts” required for development, deployment, and provisioning.
-Name: nexus-oss
-Version: 1.9.2.3
+Name: nexus
+Version: 2.0.6
 Release: 1
 License: AGPL
 Group: unknown
 URL: http://nexus.sonatype.org/
-Source0: %{name}-webapp-%{version}-bundle.tar.gz
+Source0: %{name}-%{version}-bundle.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 Requires: jdk
 AutoReqProv: no
@@ -60,6 +60,8 @@ rm -rf $RPM_BUILD_ROOT
 /var/log/nexus
 
 %changelog
+* Thu Jul 13 2012 Mike Champion <mike.champion@gmail.com> - 2.0.6
+- Upgrade to 2.0.6
 * Thu Dec 22 2011 Jens Braeuer <braeuer.jens@googlemail.com> - 1.9.2.3-1
 - Initial packaging.
 - For now nexus will run as root and listen to port 80

--- a/fetch-nexus-oss
+++ b/fetch-nexus-oss
@@ -1,11 +1,11 @@
 #! /bin/bash
 
-# http://www.sonatype.org/downloads/nexus-2.0.6-bundle.tar.gz
 readonly BASEDIR="$(dirname $(readlink -f "$0"))"
 readonly BASEURL="http://www.sonatype.org/downloads"
-readonly BINARY="nexus-2.0.6-bundle.tar.gz"
+readonly BINARY="nexus-latest-bundle.tar.gz"
 
 set -e
 mkdir -p "${BASEDIR}/SOURCES/"
 cd "${BASEDIR}/SOURCES/"
 wget "${BASEURL}/${BINARY}"
+

--- a/fetch-nexus-oss
+++ b/fetch-nexus-oss
@@ -5,7 +5,6 @@ readonly BASEURL="http://www.sonatype.org/downloads"
 readonly BINARY="nexus-latest-bundle.tar.gz"
 
 set -e
-mkdir -p "${BASEDIR}/SOURCES/"
 cd "${BASEDIR}/SOURCES/"
 wget "${BASEURL}/${BINARY}"
 

--- a/fetch-nexus-oss
+++ b/fetch-nexus-oss
@@ -1,8 +1,9 @@
 #! /bin/bash
 
+# http://www.sonatype.org/downloads/nexus-2.0.6-bundle.tar.gz
 readonly BASEDIR="$(dirname $(readlink -f "$0"))"
-readonly BASEURL="http://nexus.sonatype.org/downloads"
-readonly BINARY="nexus-oss-webapp-1.9.2.3-bundle.tar.gz"
+readonly BASEURL="http://www.sonatype.org/downloads"
+readonly BINARY="nexus-2.0.6-bundle.tar.gz"
 
 set -e
 mkdir -p "${BASEDIR}/SOURCES/"

--- a/rpm
+++ b/rpm
@@ -13,8 +13,17 @@ fi
 readonly SPEC="$(readlink -f "$1")"
 readonly BASEDIR="$(dirname $(readlink -f "$0"))"
 
+# Get downloaded file name
+stringZ=`ls ${BASEDIR}/SOURCES/nexus-*-bundle.tar.gz`
+# Parse version code
+verrel=`expr match "$stringZ" '.*nexus-\(.*\)-bundle\.tar\.gz'`
+# Sepearate version from release digits
+IFS='-' read -a verarr <<< "$verrel"
+
 mkdir -p ${BASEDIR}/{BUILD,BUILDROOT,RPMS}
 rpmbuild --verbose \
     --define "_topdir ${BASEDIR}" \
     --define "_rpmdir ${BASEDIR}/RPMS" \
+    --define "version ${verarr[0]}" \
+    --define "release ${verarr[1]}" \
     -bb "${SPEC}"


### PR DESCRIPTION
1. Fetch latest version
2. Define version and release dynamically
3. Make nexus user own files and processes
4. Patch init.d script to avoid proper shell requirement.
